### PR TITLE
Assembly definition allows Thry Editor to work

### DIFF
--- a/_PoiyomiToonShader/poiyomi.asmdef
+++ b/_PoiyomiToonShader/poiyomi.asmdef
@@ -1,0 +1,12 @@
+{
+    "name": "poiyomi",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}


### PR DESCRIPTION
If Shader is imported as package Thry Editor doesn't work without assembly definition with warning:
> Script 'XXXX' will not be compiled because it exists outside the Assets folder and does not to belong to any assembly definition file.

Solution reference:
http://baba-s.hatenablog.com/entry/2019/10/02/140000

Not sure if anyone else ran into this.