### PR TITLE
Fix "url" hierarchical parameter in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "displayName": "Poiyomi Toon Shader",
   "version": "8.1.167",
   "description": "Feature-rich shaders for Unity and VRChat.",
-  "url": "https://github.com/poiyomi/PoiyomiToonShader",
   "author": {
-    "name": "Poiyomi"
+    "name": "Poiyomi",
+    "url": "https://github.com/poiyomi/PoiyomiToonShader"
   },
   "gitDependencies": {},
   "vpmDependencies": {},


### PR DESCRIPTION
Moving the URL attribute under author should allow the VPM repo page to correctly parse the URL in the individual package's "Listing URL" when running the GitHub action task:
![image](https://github.com/poiyomi/PoiyomiToonShader/assets/25694892/12ea8572-6be3-423a-941c-bd95d24670ec)
The resulting output in https://poiyomi.github.io/vpm/index.json should then link correctly back to the package's repo.

VCC Demo Package Repo's [package.json](https://github.com/vrchat-community/template-package/blob/main/Packages/com.vrchat.demo-template/package.json) for reference