### PR TITLE
Fix legacyFolders spec for VCC 2.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "gitDependencies": {},
   "vpmDependencies": {},
   "legacyFolders": {
-    "Assets\\_PoiyomiShaders": "2fcadee009b41d847ac672dd72e80430"
+    "Assets\\_PoiyomiShaders"
   },
   "legacyFiles": {},
   "hideInEditor": false,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "gitDependencies": {},
   "vpmDependencies": {},
   "legacyFolders": {
-    "Assets\\_PoiyomiShaders"
+    "Assets\\_PoiyomiShaders": ""
   },
   "legacyFiles": {},
   "hideInEditor": false,


### PR DESCRIPTION
Fixes a serious issue in the VCC Beta 2.3.x that caused the folder to never be removed when added.

This is extremely important due to the technical changes regarding VPM Package behavior in the VCC Beta 2.3.0-beta since there's no GUIDs in Poiyomi Shader packages. @orels1 can explain the technical reasons on this situation (see the comment he'll be posting here shortly).

If this is merged, you should release the next version of Poiyomi Shaders as soon as possible with this fixed `package.json`.