### PR TITLE
Add changelogUrl for VCC

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "name": "Poiyomi",
     "url": "https://github.com/poiyomi/PoiyomiToonShader"
   },
+  "changelogUrl": "https://www.poiyomi.com/changelog",
   "gitDependencies": {},
   "vpmDependencies": {},
   "legacyFolders": {


### PR DESCRIPTION
This added string to the `package.json` will allow VCC clients to show a link to our list of changes, linking to our Documentation website.

Some community members have highly requested this improvement. Should help increase website traffic as well.