### PR TITLE
Use AudioLink band overrides even when the world provides AudioLink data

### DIFF
--- a/_PoiyomiShaders/Shaders/9.2/Toon/Poiyomi Toon Early Outline.shader
+++ b/_PoiyomiShaders/Shaders/9.2/Toon/Poiyomi Toon Early Outline.shader
@@ -8230,9 +8230,10 @@ Shader ".poiyomi/Poiyomi Toon Outline Early"
 					poiMods.globalColorTheme[9] = AudioLinkData(ALPASS_THEME_COLOR1);
 					poiMods.globalColorTheme[10] = AudioLinkData(ALPASS_THEME_COLOR2);
 					poiMods.globalColorTheme[11] = AudioLinkData(ALPASS_THEME_COLOR3);
-					return;
 				}
-				
+
+				// Even if world-supplied audiolink data was populated earlier, we want the overrides to take priority.
+				// But we keep any world-supplied global color themes, which are separate.
 				if (_AudioLinkBandOverridesEnabled)
 				{
 					poiMods.audioLinkAvailable = true;
@@ -8240,6 +8241,9 @@ Shader ".poiyomi/Poiyomi Toon Outline Early"
 					poiMods.audioLink[1] = _AudioLinkBandOverrideSliders.y;
 					poiMods.audioLink[2] = _AudioLinkBandOverrideSliders.z;
 					poiMods.audioLink[3] = _AudioLinkBandOverrideSliders.w;
+					// We don't expose an override slider for the volume band.
+					// To keep behavior consistent (no mixing sources), we don't retain world's value.
+					poiMods.audioLink[4] = 0;
 				}
 			}
 			

--- a/_PoiyomiShaders/Shaders/9.2/Toon/Poiyomi Toon Grab Pass.shader
+++ b/_PoiyomiShaders/Shaders/9.2/Toon/Poiyomi Toon Grab Pass.shader
@@ -8282,9 +8282,10 @@ Shader ".poiyomi/Poiyomi Toon Grab Pass"
 					poiMods.globalColorTheme[9] = AudioLinkData(ALPASS_THEME_COLOR1);
 					poiMods.globalColorTheme[10] = AudioLinkData(ALPASS_THEME_COLOR2);
 					poiMods.globalColorTheme[11] = AudioLinkData(ALPASS_THEME_COLOR3);
-					return;
 				}
-				
+
+				// Even if world-supplied audiolink data was populated earlier, we want the overrides to take priority.
+				// But we keep any world-supplied global color themes, which are separate.
 				if (_AudioLinkBandOverridesEnabled)
 				{
 					poiMods.audioLinkAvailable = true;
@@ -8292,6 +8293,9 @@ Shader ".poiyomi/Poiyomi Toon Grab Pass"
 					poiMods.audioLink[1] = _AudioLinkBandOverrideSliders.y;
 					poiMods.audioLink[2] = _AudioLinkBandOverrideSliders.z;
 					poiMods.audioLink[3] = _AudioLinkBandOverrideSliders.w;
+					// We don't expose an override slider for the volume band.
+					// To keep behavior consistent (no mixing sources), we don't retain world's value.
+					poiMods.audioLink[4] = 0;
 				}
 			}
 			

--- a/_PoiyomiShaders/Shaders/9.2/Toon/Poiyomi Toon Two Pass.shader
+++ b/_PoiyomiShaders/Shaders/9.2/Toon/Poiyomi Toon Two Pass.shader
@@ -8306,9 +8306,10 @@ Shader ".poiyomi/Poiyomi Toon Two Pass"
 					poiMods.globalColorTheme[9] = AudioLinkData(ALPASS_THEME_COLOR1);
 					poiMods.globalColorTheme[10] = AudioLinkData(ALPASS_THEME_COLOR2);
 					poiMods.globalColorTheme[11] = AudioLinkData(ALPASS_THEME_COLOR3);
-					return;
 				}
-				
+
+				// Even if world-supplied audiolink data was populated earlier, we want the overrides to take priority.
+				// But we keep any world-supplied global color themes, which are separate.
 				if (_AudioLinkBandOverridesEnabled)
 				{
 					poiMods.audioLinkAvailable = true;
@@ -8316,6 +8317,9 @@ Shader ".poiyomi/Poiyomi Toon Two Pass"
 					poiMods.audioLink[1] = _AudioLinkBandOverrideSliders.y;
 					poiMods.audioLink[2] = _AudioLinkBandOverrideSliders.z;
 					poiMods.audioLink[3] = _AudioLinkBandOverrideSliders.w;
+					// We don't expose an override slider for the volume band.
+					// To keep behavior consistent (no mixing sources), we don't retain world's value.
+					poiMods.audioLink[4] = 0;
 				}
 			}
 			

--- a/_PoiyomiShaders/Shaders/9.2/Toon/Poiyomi Toon World.shader
+++ b/_PoiyomiShaders/Shaders/9.2/Toon/Poiyomi Toon World.shader
@@ -8234,9 +8234,10 @@ Shader ".poiyomi/Poiyomi Toon World"
 					poiMods.globalColorTheme[9] = AudioLinkData(ALPASS_THEME_COLOR1);
 					poiMods.globalColorTheme[10] = AudioLinkData(ALPASS_THEME_COLOR2);
 					poiMods.globalColorTheme[11] = AudioLinkData(ALPASS_THEME_COLOR3);
-					return;
 				}
-				
+
+				// Even if world-supplied audiolink data was populated earlier, we want the overrides to take priority.
+				// But we keep any world-supplied global color themes, which are separate.
 				if (_AudioLinkBandOverridesEnabled)
 				{
 					poiMods.audioLinkAvailable = true;
@@ -8244,6 +8245,9 @@ Shader ".poiyomi/Poiyomi Toon World"
 					poiMods.audioLink[1] = _AudioLinkBandOverrideSliders.y;
 					poiMods.audioLink[2] = _AudioLinkBandOverrideSliders.z;
 					poiMods.audioLink[3] = _AudioLinkBandOverrideSliders.w;
+					// We don't expose an override slider for the volume band.
+					// To keep behavior consistent (no mixing sources), we don't retain world's value.
+					poiMods.audioLink[4] = 0;
 				}
 			}
 			

--- a/_PoiyomiShaders/Shaders/9.2/Toon/Poiyomi Toon.shader
+++ b/_PoiyomiShaders/Shaders/9.2/Toon/Poiyomi Toon.shader
@@ -8230,9 +8230,10 @@ Shader ".poiyomi/Poiyomi Toon"
 					poiMods.globalColorTheme[9] = AudioLinkData(ALPASS_THEME_COLOR1);
 					poiMods.globalColorTheme[10] = AudioLinkData(ALPASS_THEME_COLOR2);
 					poiMods.globalColorTheme[11] = AudioLinkData(ALPASS_THEME_COLOR3);
-					return;
 				}
-				
+
+				// Even if world-supplied audiolink data was populated earlier, we want the overrides to take priority.
+				// But we keep any world-supplied global color themes, which are separate.
 				if (_AudioLinkBandOverridesEnabled)
 				{
 					poiMods.audioLinkAvailable = true;
@@ -8240,6 +8241,9 @@ Shader ".poiyomi/Poiyomi Toon"
 					poiMods.audioLink[1] = _AudioLinkBandOverrideSliders.y;
 					poiMods.audioLink[2] = _AudioLinkBandOverrideSliders.z;
 					poiMods.audioLink[3] = _AudioLinkBandOverrideSliders.w;
+					// We don't expose an override slider for the volume band.
+					// To keep behavior consistent (no mixing sources), we don't retain world's value.
+					poiMods.audioLink[4] = 0;
 				}
 			}
 			


### PR DESCRIPTION
This makes the band override feature useful in worlds that are using AudioLink.

This new behavior is more in line with the name "override" and what the docs suggest should happen when AudioLink data already exists.

I can clarify the documentation later if you agree with this new behavior.

Technically you could consider this a breaking change, as this changes the behavior of the shader in worlds where AudioLink is in use.